### PR TITLE
Shellscript housekeeping no. 1

### DIFF
--- a/nw-watchdog
+++ b/nw-watchdog
@@ -1,7 +1,7 @@
 #!/bin/sh
-VERSION="1.1.1-main-20240419-001" # shown by --version | --help | -h
+VERSION=1.1.1-main-20240419-001 # shown by --version | --help | -h
 # running number -000 shows it's is the same as the released version (1.1.1 in this case)
-VERSION="1.1.1-development-20240419-001"
+VERSION=1.1.1-development-20240419-001
 #
 #       nw-watchdog is a higly configurable network watchdog written
 #       in POSIX shell script for use in Linux.
@@ -39,7 +39,7 @@ VERSHOW='';                         VERSHOWRE='--version';                      
 
 V=4;                                      VRE='(--verbosity-level|-V)';  VARE='[0-9]+'                  # integer greater than or equal to 0
 IFC='';                                 IFCRE='(--interface|-i)';        IFCARE='[^[:space:]/]+'        # non-empty string without whitespaces or slashes
-STATICIFC='';                     STATICIFCRE='(--force-interface|-I)';  STATICIFCARE="$IFCARE"
+STATICIFC='';                     STATICIFCRE='(--force-interface|-I)';  STATICIFCARE=$IFCARE
 LOGFILE='/var/log/nw-watchdog.log'; LOGFILERE='(--logfile|-l)';          LOGFILEARE='.+'                # non-emty string
 LOGSIZE=0;                          LOGSIZERE='(--logsize|-z)';          LOGSIZEARE='[0-9]+[kKmMgM]?'   # integer greater than or equal to 0
 PIDFILE=/run/nw-watchdog.pid;       PIDFILERE='(--pidfile|-p)';          PIDFILEARE='.+'                # non-emty string
@@ -69,19 +69,19 @@ set >/dev/null 2>&1 && export PATH >/dev/null 2>&1 || {
 # Let's put the "standard" paths first in PATH to ensure we get the standard utilities we need
 # and remove duplicates in PATH before exporting it
 NEWPATH='/sbin:/bin:/usr/sbin:/usr/bin'
-OIFS="$IFS"
-IFS=':'
+OIFS=$IFS
+IFS=:
 for p in $PATH; do
     case ":$NEWPATH:" in
         *:"$p":*) ;;
         *) NEWPATH="$NEWPATH:$p" ;;
     esac
 done
-IFS="$OIFS"
-PATH="$NEWPATH"
+IFS=$OIFS
+PATH=$NEWPATH
 export PATH
 
-DEPENDENCIES="basename cat cut date getent grep head id ip ping readlink sed sleep stat tail touch wc"
+DEPENDENCIES='cat cut date getent grep head id ip ping readlink sed sleep stat tail touch wc'
 lacking=''
 if printf '' 2>/dev/null; then
     deperr() {
@@ -91,22 +91,22 @@ if printf '' 2>/dev/null; then
 else
     lacking='printf'
     deperr() {
-        echo ' ' 1>&2
-        echo "(PATH=$PATH)" 1>&2
-        echo ' ' 1>&2
-        echo '~~~~~~~~~~~~~~~~' 1>&2
-        echo 'DEPENDENCY ERROR' 1>&2
-        echo '~~~~~~~~~~~~~~~~' 1>&2
-        echo 'The following executable(s) are lacking in your PATH:' 1>&2
-        echo "   $@" 1>&2
-        echo '... aborting!' 1>&2
-        echo ' ' 1>&2
+        echo "
+(PATH=$PATH)
+
+~~~~~~~~~~~~~~~~
+DEPENDENCY ERROR
+~~~~~~~~~~~~~~~~
+The following executable(s) are lacking in your PATH:
+   $*
+... aborting!'
+" 1>&2
         exit 1
     }
 fi
-which sh >/dev/null 2>&1 || deperr which sh $lacking
-for x in $DEPENDENCIES; do which $x>/dev/null || lacking="$lacking $x"; done
-[ -n "$lacking" ] && deperr $lacking
+which sh >/dev/null 2>&1 || deperr which sh "$lacking"
+for x in $DEPENDENCIES; do which "$x" >/dev/null || lacking="$lacking $x"; done
+[ -n "$lacking" ] && deperr "$lacking"
 
 ERRMSG=''
 COLS=72; _b_=''; ___=''; __='';
@@ -116,30 +116,30 @@ _show_errmsg() {
     while [ $i -lt $COLS ]; do div="~$div"; i=$((i+1)); done
     printf '\n%s\n%s: %s' "$_b_$div" "${_b_}ERROR$__"
     [ -n "$1" ] && {
-        PTN="$1"; shift
+        PTN=$1; shift
         printf "$PTN\n" "$@"
     }
-    LINES=`printf '%s' "$ERRMSG" | sed -E 's/\n/\t/g;s/\\[nt]/\t/g;s/%/%%/g'`
+    LINES=$(printf '%s' "$ERRMSG" | sed -E 's/\n/\t/g;s/\\[nt]/\t/g;s/%/%%/g')
     printf "$LINES" | while read l; do
         [ -n "$l" ] || break
-        l=`printf '%s' "$l" | sed -E 's/\t/\n   /g'`
+        l=$(printf '%s' "$l" | sed -E 's/\t/\n   /g')
         printf '%s %s\n' "$_b_*$__" "$l"
     done
     printf '%s\n\n' "$_b_$div"
 }
-nwwatchdog=`basename "$0"` 2>/dev/null || nwwatchdog=nw-watchdog
+nwwatchdog=${0##*/}
 _USAGE() {
     TPUTOK=1
     which tput>/dev/null 2>&1 && {
             TPUTOK=0
-            COLS=`tput cols` 2>/dev/null || TPUTOK=$((TPUTOK+1))
-            _b_=`tput bold`  2>/dev/null || TPUTOK=$((TPUTOK+1))
-            ___=`tput smul`  2>/dev/null || TPUTOK=$((TPUTOK+1))
-            #__=`tput sgr0`  2>/dev/null || TPUTOK=$((TPUTOK+1)) 'tput sgr0' in combination with 'less -R' does not work on all terminal
-            __=`printf '\033[0m'`                              #  types, so always use the universal ANSI reset escape sequence instead
+            COLS=$(tput cols) 2>/dev/null || TPUTOK=$((TPUTOK+1))
+            _b_=$(tput bold)  2>/dev/null || TPUTOK=$((TPUTOK+1))
+            ___=$(tput smul)  2>/dev/null || TPUTOK=$((TPUTOK+1))
+            #__=$(tput sgr0)  2>/dev/null || TPUTOK=$((TPUTOK+1)) 'tput sgr0' in combination with 'less -R' does not work on all terminal
+            __=$(printf '\033[0m')                              #  types, so always use the universal ANSI reset escape sequence instead
         }                                                      #  ( '\033[Om' instead of '\033[m^O' )
     [ $TPUTOK -eq 0 ] || { COLS=72; _b_=''; ___=''; __=''; }
-    FMT=cat; which fmt>/dev/null && FMT="fmt -s -w $COLS"
+    FMT='cat'; which fmt >/dev/null && FMT="fmt -s -w $COLS"
     _show_errmsg "$@"
     $FMT<<EOU
 $__
@@ -405,7 +405,7 @@ $FMT<<EOU
               --ifcdown='nmcli connection down %{IFC}-connection-name'
 
             iproute2 + isc-dhcp-client:
-              --ifcdown='kill \`cat /run/dhclient-%{IFC}.pid\` ; ip link set down %{IFC}'
+              --ifcdown='kill \$(cat /run/dhclient-%{IFC}.pid) ; ip link set down %{IFC}'
 
             strongSwan IPSec (setup for IPSec policy routing):
               --ifcup='ipsec down connection-name'
@@ -525,7 +525,7 @@ $FMT<<EOU
 EOU
 printf "        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n" \
        "  $_b_--verbosity-level=${__}3 $_b_\\" \
-       "  $_b_--alert=$__'mailx -a \"From: nwwatchdog@\`hostname -f\`\" -s \"IPSec Peer 1.2.3.4 %{STATE} via %{IFC}\" admin@\`cat /etc/mailname\`' $_b_\\" \
+       "  $_b_--alert=$__'mailx -a \"From: nwwatchdog@\$(hostname -f)\" -s \"IPSec Peer 1.2.3.4 %{STATE} via %{IFC}\" admin@\$(cat /etc/mailname)' $_b_\\" \
        "  $_b_--slow-up-timeout=${__}2 $_b_\\" \
        "  $_b_--ifup-grace=${__}10 $_b_\\" \
        "  $_b_--interval=${__}10$__" \
@@ -540,7 +540,7 @@ $FMT<<EOU
         $_b_$nwwatchdog$__ 169.254.0.1 $_b_\\
 EOU
 printf "        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n" \
-       "  $_b_--alert=$__'mailx -a \"From: nwwatchdog@\`hostname -f\`\" -s \"IPSec connection-name %{STATE} via %{IFC}\" admin@\`cat /etc/mailname\`' $_b_\\" \
+       "  $_b_--alert=$__'mailx -a \"From: nwwatchdog@\$(hostname -f)\" -s \"IPSec connection-name %{STATE} via %{IFC}\" admin@\$(cat /etc/mailname)' $_b_\\" \
        "  $_b_--force-interface=${__}ipsec0 $_b_\\" \
        "  $_b_--slow-up-timeout=${__}5 $_b_\\" \
        "  $_b_--ifup-grace=${__}25 $_b_\\" \
@@ -583,7 +583,7 @@ $FMT<<EOU
 EOU
 printf "        %s\n        %s\n        %s\n        %s\n        %s\n" \
        "  $_b_--verbosity-level=${__}3 $_b_\\" \
-       "  $_b_--alert=$__'mailx -a \"From: nwwatchdog@\`hostname -f\`\" -s \"wgserver %{STATE} via %{IFC}\" admin@\`cat /etc/mailname\`' $_b_\\" \
+       "  $_b_--alert=$__'mailx -a \"From: nwwatchdog@\$(hostname -f)\" -s \"wgserver %{STATE} via %{IFC}\" admin@\$(cat /etc/mailname)' $_b_\\" \
        "  $_b_--slow-up-timeout=${__}3 $_b_\\" \
        "  $_b_--ifup-grace=${__}20 $_b_\\" \
        "  $_b_--install-systemd=${__}wgserver"
@@ -597,7 +597,7 @@ EOU
 printf "        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n" \
        "  $_b_--no-ping-nexthop \\" \
        "  $_b_--verbosity-level=${__}3 $_b_\\" \
-       "  $_b_--alert=$__'mailx -a \"From: nwwatchdog@\`hostname -f\`\" -s \"wireguard wg0\" admin@\`cat /etc/mailname\`' $_b_\\" \
+       "  $_b_--alert=$__'mailx -a \"From: nwwatchdog@\$(hostname -f)\" -s \"wireguard wg0\" admin@\$(cat /etc/mailname)' $_b_\\" \
        "  $_b_--force-interface=${__}wg0 $_b_\\" \
        "  $_b_--ifcup=$__'ip link add wg0 type wireguard ;" \
        "           ip link set wg0 up ;" \
@@ -605,7 +605,7 @@ printf "        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n
        "           ip address add 10.0.0.2 peer 10.0.0.1 dev wg0 ;" \
        "           getent ahostsv4 wgserver.my.dom | grep -oE \"^[0-9.]+\" | uniq" \
        "           | while read addr; do" \
-       "               ip route add \$addr/32 via \`ip route show default | head -1 | cut -d\" \" -f3\` ;" \
+       "               ip route add \$addr/32 via \$(ip route show default | head -1 | while read -r _ _ i _; do echo \$i; done) ;" \
        "             done ;" \
        "           ip route add 0.0.0.0/1 via 10.0.0.1 dev wg0 src 10.0.0.2 ;" \
        "           ip route add 128.0.0.0/1 via 10.0.0.1 dev wg0 src 10.0.0.2'$__ $_b_\\" \
@@ -617,7 +617,7 @@ printf "        %s\n        %s\n        %s\n        %s\n        %s\n        %s\n
     $___${_b_}OBSERVE$__ that the entire $_b_--ifcup=$__'...' command needs to be on a single line without line breaks (linebreaks added above for readability):
 
 EOU
-printf "        %s\n" "$_b_--ifcup=$__'ip link add wg0 type wireguard ; ip link set wg0 up ; wg setconf wg0 /etc/wireguard/wg0.conf ; ip address add 10.0.0.2 peer 10.0.0.1 dev wg0 ; getent ahostsv4 wgserver.my.dom | grep -oE \"^[0-9.]+\" | uniq | while read addr; do ip route add \$addr/32 via \`ip route show default | head -1 | cut -d\" \" -f3\` ; done ; ip route add 0.0.0.0/1 via 10.0.0.1 dev wg0 src 10.0.0.2 ; ip route add 128.0.0.0/1 via 10.0.0.1 dev wg0 src 10.0.0.2'"
+printf "        %s\n" "$_b_--ifcup=$__'ip link add wg0 type wireguard ; ip link set wg0 up ; wg setconf wg0 /etc/wireguard/wg0.conf ; ip address add 10.0.0.2 peer 10.0.0.1 dev wg0 ; getent ahostsv4 wgserver.my.dom | grep -oE \"^[0-9.]+\" | uniq | while read addr; do ip route add \$addr/32 via \$(ip route show default | head -1 | while read -r _ _ i _; do echo \$i; done) ; done ; ip route add 0.0.0.0/1 via 10.0.0.1 dev wg0 src 10.0.0.2 ; ip route add 128.0.0.0/1 via 10.0.0.1 dev wg0 src 10.0.0.2'"
 $FMT<<EOU
 
     We use $_b_--no-ping-nexthop$__ as the NEXTHOP is the same as the ${___}TARGET${__} peer-to-peer address we monitor the connection for (in reality we don't need to specify it as it is the default behaviour if the ${___}TARGET${__} address is the same as the NEXTHOP address).
@@ -768,11 +768,11 @@ for o in $AOPTIONS; do
     eval "r='\${${o}RE'}"; eval "AOPTRE=\"$AOPTRE$r\"" # should be \" or AOPTRE will contain variabel names instead of content
 done
 AOPTRE="($AOPTRE)"
-NDOPTRE=`printf "%s|%s" "$SOPTRE" "$AOPTRE" | sed -E 's/\(-*|\)//g' | sed -E 's/\|-*/\|/g'`
+NDOPTRE=$(printf "%s|%s" "$SOPTRE" "$AOPTRE" | sed -E 's/\(-*|\)//g' | sed -E 's/\|-*/\|/g')
 
-xOPTIONS=':'
+xOPTIONS=:
 while [ $# -gt 0 ]; do
-    ARG="$1"; shift
+    ARG=$1; shift
     if printf %s "$ARG" | grep -qE "^${SOPTRE}$"; then                      # No Argument Option
         for o in $SOPTIONS; do
             eval "R=\"\${${o}RE}\"" # should be \" or R will contain variabel names instead of content
@@ -783,20 +783,20 @@ while [ $# -gt 0 ]; do
             fi
         done
     elif printf %s "$ARG" | grep -qE "^-${SOPTSRE}(${NDOPTRE})"; then       # Grouped Options
-        A=`printf "%s" "$ARG" | grep -oE '^..'`
-        B=`printf "%s" "$ARG" | cut -c3-`
+        A=$(printf "%s" "$ARG" | grep -oE '^..')
+        B=$(printf "%s" "$ARG" | cut -c3-)
         set -- "$A" "-$B" "$@"
     elif printf %s "$ARG" | grep -qE "^${AOPTRE}"; then                     # Option with Argument
         if printf %s "$ARG" | grep -qE "^${AOPTRE}$"; then                  # Option [space] Argument
             OPT=$ARG
-            ARG="$1"
+            ARG=$1
             [ $# -gt 0 ] && shift
         elif printf "%s" "$ARG" | grep -qE  "^${AOPTRE}=[^[:space:]]"; then # Option [equals] Argument
-            OPT="${ARG%%=*}"
-            ARG="${ARG#*=}"
+            OPT=${ARG%%=*}
+            ARG=${ARG#*=}
         else                                                                # Option [no-space] Argument
-            OPT=`printf %s "$ARG" | grep -oE "^${AOPTRE}"`
-            ARG=`printf "%s" "$ARG" | sed -E "s/^${AOPTRE}//"`
+            OPT=$(printf %s "$ARG" | grep -oE "^${AOPTRE}")
+            ARG=$(printf "%s" "$ARG" | sed -E "s/^${AOPTRE}//")
             [ "$ARG" = '=' ] && {
                 ERRMSG="'$OPT=' seem to lack an arugment.\tIf the argument really should be '=', use the syntax '$OPT=='.\n$ERRMSG"
                 ARG=''
@@ -829,7 +829,7 @@ while [ $# -gt 0 ]; do
             ERRMSG="Invalid OPTION: '$ARG'\n$ERRMSG"
         else
             [ -z "$TARGET" ] || ERRMSG="Multiple TARGETs specified ('$TARGET' + '$ARG').\n$ERRMSG"
-            TARGET="$ARG"
+            TARGET=$ARG
             printf "%s" "$TARGET" \
                 | grep -qE '^((0*[0-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}(0*[0-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))$' \
                 || printf "%s" "$TARGET" \
@@ -855,9 +855,9 @@ done
             exit 0
         }
         [ -n "$RMSYSTEMDSERVICE" ] || ERRMSG='' USAGE %s "--remove-systemd requires a service or unit name to remove"
-        [ `id -u` -eq 0 ] || USAGE %s "$nwwatchdog --remove-systemd must be run as root"
+        [ $(id -u) -eq 0 ] || USAGE %s "$nwwatchdog --remove-systemd must be run as root"
         systemctl daemon-reload || USAGE %s "Failed to reload systemd. Is systemd installed and running?"
-        UNITNAME="$RMSYSTEMDSERVICE"
+        UNITNAME=$RMSYSTEMDSERVICE
         systemctl list-unit-files "$UNITNAME" >/dev/null 2>&1 || {
             UNITNAME="nw-watchdog-$RMSYSTEMDSERVICE.service"
             systemctl list-unit-files "$UNITNAME" >/dev/null 2>&1 \
@@ -865,9 +865,9 @@ done
                          "$RMSYSTEMDSERVICE" "$UNITNAME" \
                          "Use --list-systemd to list all nw-watchdog systemd units."
         }
-        systemctl stop "$UNITNAME" || printf "\nWARNING: failed to stop '$UNITNAME'\n" 1>&2
-        systemctl disable "$UNITNAME" || printf "\nWARNING: failed to disable '$UNITNAME'\n" 1>&2
-        rm -vf "/etc/systemd/system/$UNITNAME" || printf "\nWARNING: failed to remove '/etc/systemd/system/$UNITNAME'\n" 1>&2
+        systemctl stop "$UNITNAME" || printf "\nWARNING: failed to stop '%s'\n" "$UNITNAME" 1>&2
+        systemctl disable "$UNITNAME" || printf "\nWARNING: failed to disable '%s'\n" "$UNITNAME" 1>&2
+        rm -vf "/etc/systemd/system/$UNITNAME" || printf "\nWARNING: failed to remove '/etc/systemd/system/%s'\n" "$UNITNAME" 1>&2
         systemctl daemon-reload || printf "\nWARNING: Failed to reload systemd." 1>&2
         exit 0
     }
@@ -889,8 +889,8 @@ done
     printf %s "$xOPTIONS" | grep -qE ':SLOWUPTIMEOUT:' || SLOWUPTIMEOUT=1
     printf %s "$xOPTIONS" | grep -qE ':SLEEP:'         || SLEEP=3
     printf %s "$xOPTIONS" | grep -qE ':GRACE:'         || GRACE=5
-    printf %s "$xOPTIONS" | grep -qE ':ALERTCMDT:'     || ALERTCMDT=cat
-    printf %s "$xOPTIONS" | grep -qE ':ALERTCMD:'      || ALERTCMD=cat
+    printf %s "$xOPTIONS" | grep -qE ':ALERTCMDT:'     || ALERTCMDT='cat'
+    printf %s "$xOPTIONS" | grep -qE ':ALERTCMD:'      || ALERTCMD='cat'
     FORK=''
 }
 [ "$LOGFILE" = '-' ] && { LOGSIZE=0 ; LOGSIZEb=0 ; LOGFILE='' ;}
@@ -913,11 +913,11 @@ dienl() {
               "Fix permissions, run as user with access or specify another --logfile."
 }
 
-LOGSIZEb="$LOGSIZE"
+LOGSIZEb=$LOGSIZE
 case "$LOGSIZEb" in
-    *[Kk]) LOGSIZEb=`printf "%s" "$LOGSIZEb" | sed -E 's/[Kk]$//'` ;;
-    *[Mm]) LOGSIZEb=`printf "%s" "$LOGSIZEb" | sed -E 's/[Mm]$//'`; LOGSIZEb=$((LOGSIZEb*1024)) ;;
-    *[Gg]) LOGSIZEb=`printf "%s" "$LOGSIZEb" | sed -E 's/[Gg]$//'`; LOGSIZEb=$((LOGSIZEb*1048576)) ;;
+    *[Kk]) LOGSIZEb=$(printf "%s" "$LOGSIZEb" | sed -E 's/[Kk]$//') ;;
+    *[Mm]) LOGSIZEb=$(printf "%s" "$LOGSIZEb" | sed -E 's/[Mm]$//'); LOGSIZEb=$((LOGSIZEb*1024)) ;;
+    *[Gg]) LOGSIZEb=$(printf "%s" "$LOGSIZEb" | sed -E 's/[Gg]$//'); LOGSIZEb=$((LOGSIZEb*1048576)) ;;
 esac
 LOGSIZEb=$((LOGSIZEb*1024))
 
@@ -925,18 +925,18 @@ test -n "$STATICIFC" && { CONTINUOUSTOPOLOGYDETECT='' ; IFC=$STATICIFC ;}
 
 log() {
     logPATN="%s  $1"; shift
-    logentry=$(printf "$logPATN" "`date '+%Y-%m-%d %H:%M:%S %z'`" "$@")
+    logentry=$(printf "$logPATN" "$(date '+%Y-%m-%d %H:%M:%S %z')" "$@")
     if [ -n "$LOGFILE" ]; then
         [ "$LOGSIZEb" -gt 0 ] && {
             # Remove top 10 lines until log file is smaller than LOGSIZEb,
             # silently skip if we can't lock the file
             if which flock >/dev/null 2>&1; then
                 skip=''
-                while [ -z "$skip" -a `stat --printf='%s' $LOGFILE` -gt $LOGSIZEb ]; do
+                while [ -z "$skip" -a $(stat --printf='%s' $LOGFILE) -gt $LOGSIZEb ]; do
                     flock -w1 "$LOGFILE" -c "cp '$LOGFILE' '$LOGFILE.$$' ; tail -n +11 '$LOGFILE.$$' >'$LOGFILE'; rm '$LOGFILE.$$'" || skip=y
                 done
             else
-                while [ `stat --printf='%s' $LOGFILE` -gt $LOGSIZEb ]; do
+                while [ $(stat --printf='%s' $LOGFILE) -gt $LOGSIZEb ]; do
                     cp "$LOGFILE" "$LOGFILE.$$" ; tail -n +11 "$LOGFILE.$$" > "$LOGFILE" ; rm "$LOGFILE.$$"
                 done
             fi
@@ -946,10 +946,10 @@ log() {
                 [ $V -ge 2 ] && {
                     printf "WARNING: Could not lock logfile temporarily logging to '%s'\n" "$LOGFILE.$$" 1>&2
                 }
-                TLOGFILE="$LOGFILE"
+                TLOGFILE=$LOGFILE
                 LOGFILE="$LOGFILE.$$"
                 printf "%s\n" "$logentry" >>"$LOGFILE"
-                LOGFILE="$TLOGFILE"
+                LOGFILE=$TLOGFILE
             }
         else
             printf "%s\n" "$logentry" >>"$LOGFILE"
@@ -961,53 +961,53 @@ log() {
 ALERTSTATE='INITIAL'
 alert() {
     [ $V -ge 3 ] || return
-    STATE="$1"; shift
+    STATE=$1; shift
 
-    [ "$STATE" = "ERROR" -o "$STATE" = "WARNING" -o "$STATE" = "INITIAL" ] || { # always alert on ERROR, WARNING and INITIAL
-        [ "$ALERTSTATE" = "INITIAL" ] && {                                      # Do not alert if we are up after INITIAL
-            [ "$STATE" = "UP" -o "$STATE" = "REACHABLE" -o "$STATE" = "LINKUP" ] && return
+    [ "$STATE" = ERROR -o "$STATE" = WARNING -o "$STATE" = INITIAL ] || { # always alert on ERROR, WARNING and INITIAL
+        [ "$ALERTSTATE" = INITIAL ] && {                                      # Do not alert if we are up after INITIAL
+            [ "$STATE" = UP -o "$STATE" = REACHABLE -o "$STATE" = LINKUP ] && return
         }
-        [ "$STATE" = "$ALERTSTATE" ] && return                                # Same state
-        [ "$ALERTSTATE" = "LINKDOWN" -a "$STATE" = "DOWN" ] && return         # LINKDOWN implies DOWN
-        [ "$ALERTSTATE" = "LINKDOWN" -a "$STATE" = "UNREACHABLE" ] && return  # LINKDOWN implies UNREACHABLE
-        [ "$ALERTSTATE" = "UNREACHABLE" -a "$STATE" = "DOWN" ] && return      # UNREACHABLE implies DOWN
-        [ "$ALERTSTATE" = "UP" -a "$STATE" = "REACHABLE" ] && return          # UP implies REACHABLE
-        [ "$ALERTSTATE" = "UP" -a "$STATE" = "LINKUP" ] && return             # UP implies LINKUP
-        [ "$REACHABLE"  = "REACHABLE" -a "$STATE" = "LINKUP" ] && return      # REACHABLE implies LINKUP
+        [ "$STATE" != "$ALERTSTATE" ] && return                                # Same state
+        [ "$ALERTSTATE" = LINKDOWN -a "$STATE" = DOWN ] && return         # LINKDOWN implies DOWN
+        [ "$ALERTSTATE" = LINKDOWN -a "$STATE" = UNREACHABLE ] && return  # LINKDOWN implies UNREACHABLE
+        [ "$ALERTSTATE" = UNREACHABLE -a "$STATE" = DOWN ] && return      # UNREACHABLE implies DOWN
+        [ "$ALERTSTATE" = UP -a "$STATE" = REACHABLE ] && return          # UP implies REACHABLE
+        [ "$ALERTSTATE" = UP -a "$STATE" = LINKUP ] && return             # UP implies LINKUP
+        [ "$REACHABLE"  = REACHABLE -a "$STATE" = LINKUP ] && return      # REACHABLE implies LINKUP
     }
-    ALERTCMD=`printf "%s" "$ALERTCMDT" | sed -E "s/\%\{STATE\}/$STATE/g" | sed -E "s/\%\{LASTSTATE\}/$ALERTSTATE/g"`
+    ALERTCMD=$(printf "%s" "$ALERTCMDT" | sed -E "s/\%\{STATE\}/$STATE/g" | sed -E "s/\%\{LASTSTATE\}/$ALERTSTATE/g")
     if [ -n "$TARGET" ]; then
-        ALERTCMD=`printf "%s" "$ALERTCMD" | sed -E "s/\%\{TARGET\}/$TARGET/g"`
+        ALERTCMD=$(printf "%s" "$ALERTCMD" | sed -E "s/\%\{TARGET\}/$TARGET/g")
     else
-        ALERTCMD=`printf "%s" "$ALERTCMD" | sed -E "s/\%\{TARGET\}/unspecified-target/g"`
+        ALERTCMD=$(printf "%s" "$ALERTCMD" | sed -E "s/\%\{TARGET\}/unspecified-target/g")
     fi
 
     if [ -n "$IFC" ]; then
-        ALERTCMD=`printf "%s" "$ALERTCMD" | sed -E "s/\%\{IFC\}/$IFC/g"`
+        ALERTCMD=$(printf "%s" "$ALERTCMD" | sed -E "s/\%\{IFC\}/$IFC/g")
     else
-        ALERTCMD=`printf "%s" "$ALERTCMD" | sed -E "s/\%\{IFC\}/topology-not-yet-detected/g"`
+        ALERTCMD=$(printf "%s" "$ALERTCMD" | sed -E "s/\%\{IFC\}/topology-not-yet-detected/g")
     fi
 
     if [ -n "$TADDR" ]; then
-        ALERTCMD=`printf "%s" "$ALERTCMD" | sed -E "s/\%\{TADDR\}/$TADDR/g"`
+        ALERTCMD=$(printf "%s" "$ALERTCMD" | sed -E "s/\%\{TADDR\}/$TADDR/g")
     else
-        ALERTCMD=`printf "%s" "$ALERTCMD" | sed -E "s/\%\{TADDR\}/unresolved-target/g"`
+        ALERTCMD=$(printf "%s" "$ALERTCMD" | sed -E "s/\%\{TADDR\}/unresolved-target/g")
     fi
 
     if [ -n "$NEXTHOP" ]; then
-        ALERTCMD=`printf "%s" "$ALERTCMD" | sed -E "s/\%\{NEXTHOP\}/$NEXTHOP/g"`
+        ALERTCMD=$(printf "%s" "$ALERTCMD" | sed -E "s/\%\{NEXTHOP\}/$NEXTHOP/g")
     else
-        ALERTCMD=`printf "%s" "$ALERTCMD" | sed -E "s/\%\{NEXTHOP\}/topology-not-yet-detected/g"`
+        ALERTCMD=$(printf "%s" "$ALERTCMD" | sed -E "s/\%\{NEXTHOP\}/topology-not-yet-detected/g")
     fi
 
-    alertPATN="$1" ; shift
+    alertPATN=$1 ; shift
     printf "\n\n$nwwatchdog $STATE ALERT!!!\n$alertPATN\n\n\n" "$@" | sh -c "$ALERTCMD"
 
     case "$STATE" in
-        "ERROR") LSTATE="  ERROR:" ;;
-        "WARNING") LSTATE="WARNING:" ;;
+        "ERROR") LSTATE='  ERROR:' ;;
+        "WARNING") LSTATE='WARNING:' ;;
         *)
-            ALERTSTATE="$STATE"
+            ALERTSTATE=$STATE
             LSTATE="  ALERT: $STATE -"
             ;;
     esac
@@ -1029,17 +1029,17 @@ warn() {
 }
 info() {
     [ $V -ge 4 ] || return
-    infoPATN="$1" ; shift
+    infoPATN=$1 ; shift
     log "   INFO: $infoPATN" "$@"
 }
 trace() {
     [ $V -ge 5 ] || return
-    tracePATN="$1" ; shift
+    tracePATN=$1 ; shift
     log "  TRACE: $tracePATN" "$@"
 }
 debug() {
     [ $V -ge 6 ] || return
-    debugPATN="$1" ; shift
+    debugPATN=$1 ; shift
     log "  DEBUG: $debugPATN" "$@"
 }
 
@@ -1051,19 +1051,20 @@ ifreset() {
     [ -n "$IFC" ] || die "Internal ERROR: No interface to reset!"
     info "Resetting interface (%s)." "$IFC"
     trace "sh -c '%s'" "$IFCDOWN"
-    IFCDD=`sh -c "$IFCDOWN" 2>&1`; EXITCODE=$?
+    IFCDD=$(sh -c "$IFCDOWN" 2>&1)
+    EXITCODE=$?
 
     debug "ifcdown: '%s'\n\texited with $EXITCODE and output:\n\t%s" "$IFCDOWN" "$IFCDD"
     sleep 1
     trace "sh -c '%s'" "$IFCUP"
     EXITCODE=0
-    IFCUD=`sh -c "$IFCUP" 2>&1`|| {
+    IFCUD=$(sh -c "$IFCUP" 2>&1) || {
         EXITCODE=$?
         debug "ifcup: '%s'\n\texited with $EXITCODE and output:\n\t%s" "$IFCUP" "$IFCUD"
         warn "%s\n\t%s" \
              "Could not reset interface '$IFC'." \
-             "Check your --if-up and --if-down commands and/or privilegdes of effective user (userid=`id -u`)."
-        [ -n "$1" ] && return 1
+             "Check your --if-up and --if-down commands and/or privilegdes of effective user (userid=$(id -u))."
+        [ -z "$1" ] || return 1
     }
     debug "'%s' exited with $EXITCODE and output: '%s'" "$IFCUP" "$IFCUD"
     trace "Sleeping for $GRACE seconds."
@@ -1101,21 +1102,21 @@ linkcheck() {
 }
 
 nexthop() {
-    NIFC="`ip route get $TADDR | grep -o 'dev [^ ]*' | cut -d' ' -f2`"
+    NIFC=$(ip route get $TADDR | grep -o 'dev [^ ]*' | while read -r _ h _; do echo $h; done)
     if [ -n "$NIFC" ]; then
-        NNEXTHOP="`ip route get $TADDR | grep -oE 'via [^ ]*' | cut -d' ' -f2`"
+        NNEXTHOP=$(ip route get $TADDR | grep -oE 'via [^ ]*' | while read -r _ h _; do echo $h; done)
         [ -z "$NNEXTHOP" ] && {
-            NNEXTHOP="$TADDR"
+            NNEXTHOP=$TADDR
             debug "No nexthop detected (ok if same subnet (incl. host-local addr) or peer-to-peer addr), using target as nexthop... "
             # If it's a host-local address 'ip route get' will give lo as source interface even if addr is on different interface
             # which will cause 'ping -I$IFC' to fail, so let's figure which the interface with the address is instead
-            [ "$NIFC" = "lo" ] && {
-                nexthopADDR=`printf '%s' "$TADDR" | sed -E 's/\./\\\\./g'`
-                [ -n "`ip addr | grep -E "inet $nexthopADDR( |\/)"`" ] && {
-                    LIFC="`ip addr | grep -B9999 -E "inet $nexthopADDR( |\/)" | grep -oE '^[0-9]+:\s+[^@:]+' | tail -1 | sed -E 's/.*\s//'`"
+            [ "$NIFC" = lo ] && {
+                nexthopADDR=$(printf '%s' "$TADDR" | sed -E 's/\./\\\\./g')
+                [ -n "$(ip addr | grep -E "inet $nexthopADDR( |\/)")" ] && {
+                    LIFC=$(ip addr | grep -B9999 -E "inet $nexthopADDR( |\/)" | grep -oE '^[0-9]+:\s+[^@:]+' | tail -1 | sed -E 's/.*\s//')
                     [ -n "$LIFC" ] && {
                         debug "Found $TADDR on local interface '$LIFC' (overriding '$NIFC')"
-                        NIFC="$LIFC"
+                        NIFC=$LIFC
                     }
                 }
             }
@@ -1125,16 +1126,16 @@ nexthop() {
             return 0
         elif [ -z "$STATICIFC" ]; then
             info "Detected topology: IFC='%s' -> '%s' ; NEXTHOP='%s' -> '%s'" "$IFC" "$NIFC" "$NEXTHOP" "$NNEXTHOP"
-            IFC="$NIFC"
-            NEXTHOP="$NNEXTHOP"
-            IFCUP=`printf "%s" "$IFCUPT" | sed -E "s/\%\{IFC\}/$IFC/g"`
-            IFCDOWN=`printf "%s" "$IFCDOWNT" | sed -E "s/\%\{IFC\}/$IFC/g"`
+            IFC=$NIFC
+            NEXTHOP=$NNEXTHOP
+            IFCUP=$(printf "%s" "$IFCUPT" | sed -E "s/\%\{IFC\}/$IFC/g")
+            IFCDOWN=$(printf "%s" "$IFCDOWNT" | sed -E "s/\%\{IFC\}/$IFC/g")
             return 0
         elif [ "$STATICIFC" = "$NIFC" ]; then
             info "Detected topology on forced interface '%s': NEXTHOP='%s' -> '%s'" "$IFC" "$NEXTHOP" "$NNEXTHOP"
             debug "STATICIFC='%s' IFC='%s' NIFC='%s' NEXTHOP='%s' NNEXTHOP='%s'" \
                   "$STATICIFC" "$IFC" "$NIFC" "$NEXTHOP" "$NNEXTHOP"
-            NEXTHOP="$NNEXTHOP"
+            NEXTHOP=$NNEXTHOP
             return 0
         else
             info "Ignoring conflicting topology: Route to target '%s' (%s) is on interface '%s', but --force-interface='%s'" \
@@ -1149,7 +1150,7 @@ nexthop() {
 }
 
 [ -n "$FORK" -o -n "$SYSTEMDSERVICENAME" ] && {
-    debug "MAINPID=$$ BASENAME=$nwwatchdog COMM=`cat /proc/$$/comm`"
+    debug "MAINPID=$$ BASENAME=$nwwatchdog COMM=$(cat /proc/$$/comm)"
 
     NOPTS='M' # don't use a pager for output from background / systemd processes
     [ -z "$PINGNEXTHOP" ] && NOPTS="${NOPTS}N"
@@ -1170,9 +1171,9 @@ nexthop() {
         USAGE "Invalid systemd service name '%s'\n       %s\n       %s" "$SYSTEMDSERVICENAME" \
               "The SYSTEMDSERVICENAME must contain only alphanumeric characters, hyphens and underscores" \
               "and be no longer than 236 characters."
-    [ `printf "%s" "$SYSTEMDSERVICENAME" | wc -c` -gt 236 ] && USAGE "Systemd service name\n       '%s'\n       %s" \
+    [ $(printf "%s" "$SYSTEMDSERVICENAME" | wc -c) -gt 236 ] && USAGE "Systemd service name\n       '%s'\n       %s" \
                                                                      "$SYSTEMDSERVICENAME" "is too long (max 236 characters)" 
-    [ `id -u` -eq 0 ] || USAGE %s "$nwwatchdog --install-systemd must be run as root"
+    [ $(id -u) -eq 0 ] || USAGE %s "$nwwatchdog --install-systemd must be run as root"
     [ -d /etc/systemd/system/. ] || USAGE "'/etc/systemd/system/' does not exists,\n       systemd '%s.service' NOT installed!" \
                                           "$SYSTEMDSERVICENAME"
     for DIR in /run/nw-watchdog /var/log/nw-watchdog; do # /var/log/nw-watchdog/$SYSTEMDSERVICENAME.systemd; do
@@ -1192,7 +1193,7 @@ Wants=network.target
 Type=forking
 KillMode=process
 PIDFile=/var/run/nw-watchdog/$SYSTEMDSERVICENAME.pid
-ExecStart=/bin/sh '`readlink -e "$0"`' '$TARGET' -$NOPTS$AOPTS -p/var/run/nw-watchdog/$SYSTEMDSERVICENAME.pid -l/var/log/nw-watchdog/$SYSTEMDSERVICENAME.log
+ExecStart=/bin/sh '$(readlink -e "$0")' '$TARGET' -$NOPTS$AOPTS -p/var/run/nw-watchdog/$SYSTEMDSERVICENAME.pid -l/var/log/nw-watchdog/$SYSTEMDSERVICENAME.log
 
 [Install]
 WantedBy=sysinit.target
@@ -1207,8 +1208,8 @@ EOF
 }
 
 resolve_target() {
-    rtOADDR="$TADDR"
-    TADDR=`getent ahostsv4 "$TARGET" | head -1 | sed -E 's/^\s*([0-9.]+)\s.*/\1/'`
+    rtOADDR=$TADDR
+    TADDR=$(getent ahostsv4 "$TARGET" | head -1 | sed -E 's/^\s*([0-9.]+)\s.*/\1/')
     [ -n "$TADDR" ] || {
         TADDR=$rtOADDR
         info "Failed to resolve target '%s', keeping '%s'" "$TARGET" "$TADDR"
@@ -1223,7 +1224,7 @@ resolve_target() {
 }
 
 isup() {
-    isupADDR="$1"
+    isupADDR=$1
 
     [ "$isupADDR" = "$NEXTHOP" ] && {
         # addr is on local subnet (incl. host-local addrs) or peer-to-peer address
@@ -1262,7 +1263,7 @@ isup() {
     # We don't get traffic through
     debug "$isupADDR not-up via $IFC"
 
-    [ "$2" = "noresolve" ] && return 1
+    [ "$2" != noresolve ] || return 1
     isupOADDR=$TADDR
     if resolve_target; then
         [ "$isupOADDR" = "$TADDR" ] || {
@@ -1285,8 +1286,8 @@ isup() {
 
 [ -n "$PIDFILE" ] || PIDFILE=/run/nw-watchdog.pid
 touch "$PIDFILE" 2>/dev/null || die "%s\n%s" "Cannot write to pidfile '$PIDFILE'." \
-                                    "Specify another --pidfile or check permissions or privileges of effective user (userid=`id -u`)"
-PID=`cat "$PIDFILE"`
+                                    "Specify another --pidfile or check permissions or privileges of effective user (userid=$(id -u))"
+PID=$(cat "$PIDFILE")
 [ "$PID" -gt 0 ] 2>/dev/null && [ -d /proc/$PID ] && die "Process already running with pid $PID"
 
 ### Forking
@@ -1305,7 +1306,7 @@ PID=`cat "$PIDFILE"`
 }
 
 printf $$ > "$PIDFILE"
-debug "PID=$$ BASENAME=$nwwatchdog COMM=`cat /proc/$$/comm`"
+debug "PID=$$ BASENAME=$nwwatchdog COMM=$(cat /proc/$$/comm)"
 
 debug "\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s" \
       "~~~ SETTINGS ~~~" \
@@ -1332,8 +1333,8 @@ debug "\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\
 
 TADDR=''
 [ -n "$IFC" ] && {
-    IFCUP=`printf "%s" "$IFCUPT" | sed -E "s/\%\{IFC\}/$IFC/g"`
-    IFCDOWN=`printf "%s" "$IFCDOWNT" | sed -E "s/\%\{IFC\}/$IFC/g"`
+    IFCUP=$(printf "%s" "$IFCUPT" | sed -E "s/\%\{IFC\}/$IFC/g")
+    IFCDOWN=$(printf "%s" "$IFCDOWNT" | sed -E "s/\%\{IFC\}/$IFC/g")
 
     ip link show $IFC>/dev/null 2>&1 || { # device does not exist
         if [ -n "$IFCUPDOWN" ]; then
@@ -1342,8 +1343,7 @@ TADDR=''
             trace "Sleeping for $GRACE seconds."
             sleep $GRACE
             if [ -n "$STATICIFC" ]; then
-                ip link show $IFC >/dev/null 2>&1
-                while [ $? -ne 0 ]; do
+                while ! ip link show $IFC >/dev/null 2>&1; do
                     warn "--force-interface '%s' not available (no such device), will keep trying to bring it up.\n\t%s" "$IFC" \
                          "... or you might want to check your options and restart this instance with correct ones if wrong."
                     sh -c "$IFCUP" >/dev/null 2>&1
@@ -1399,7 +1399,7 @@ TADDR=''
 debug "Resolving, or if already IP address, cleaning zero-padding of, target '%s'" "$TARGET"
 # Clean up zero-padding if TARGET is an IP address
 printf "%s" "$TARGET" | grep -qE '^((0*[0-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}(0*[0-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))$' \
-    && TARGET=`printf "%s" "$TARGET" | sed -E 's/(^|\.)0+([1-9]+)/\1\2/g'`
+    && TARGET=$(printf "%s" "$TARGET" | sed -E 's/(^|\.)0+([1-9]+)/\1\2/g')
 
 while [ -z "$TADDR" ]; do
     resolve_target || {


### PR DESCRIPTION
- Use $() instead of backticks
- Avoid variables in printf string pattern
- Use single quotes instead of double where possible
- No quotes needed when assigning variable from other variable
- No quotes needed for simple static string w/o whitespaces
- Use command directly instead of if statement on exit code
- Use single echo command instead of multiple consecutive
- Use built-in shell script string operation instead of basename