### PR TITLE
Minimal quoting for constant strings (single-quote / bare where no vars)

### DIFF
--- a/nw-watchdog
+++ b/nw-watchdog
@@ -848,7 +848,7 @@ done
 
 [ $LISTSYSTEMD ] || printf %s "$xOPTIONS" | grep -qE ':RMSYSTEMDSERVICE:' && {
         printf %s "$xOPTIONS" | grep -qE ':.*:.*:' || [ "$TARGET" ] && \
-            ERRMSG='' USAGE %s "--list-systemd and --remove-systemd cannot be combined with any other option"
+            ERRMSG='' USAGE %s '--list-systemd and --remove-systemd cannot be combined with any other option'
         [ -d /etc/systemd/system/. ] || USAGE "'/etc/systemd/system/' does not exists, is systemd installed and running?"
         [  -n "$LISTSYSTEMD" ] && {
             printf '\n\n--- Listing all loaded nw-watchdog systemd units: ---\n'
@@ -857,9 +857,9 @@ done
             systemctl list-unit-files --all nw-watchdog-\* 2>/dev/null
             exit 0
         }
-        [ "$RMSYSTEMDSERVICE" ] || ERRMSG='' USAGE %s "--remove-systemd requires a service or unit name to remove"
+        [ "$RMSYSTEMDSERVICE" ] || ERRMSG='' USAGE %s '--remove-systemd requires a service or unit name to remove'
         [ $(id -u) -eq 0 ] || USAGE %s "$nwwatchdog --remove-systemd must be run as root"
-        systemctl daemon-reload || USAGE %s "Failed to reload systemd. Is systemd installed and running?"
+        systemctl daemon-reload || USAGE %s 'Failed to reload systemd. Is systemd installed and running?'
         UNITNAME=$RMSYSTEMDSERVICE
         systemctl list-unit-files "$UNITNAME" >/dev/null 2>&1 || {
             UNITNAME="nw-watchdog-$RMSYSTEMDSERVICE.service"
@@ -1006,8 +1006,8 @@ alert() {
     printf "\n\n$nwwatchdog $STATE ALERT!!!\n$alertPATN\n\n\n" "$@" | sh -c "$ALERTCMD"
 
     case "$STATE" in
-        "ERROR") LSTATE='  ERROR:' ;;
-        "WARNING") LSTATE='WARNING:' ;;
+        ERROR) LSTATE='  ERROR:' ;;
+        WARNING) LSTATE='WARNING:' ;;
         *)
             ALERTSTATE=$STATE
             LSTATE="  ALERT: $STATE -"
@@ -1085,7 +1085,7 @@ linkcheck() {
                 [ "$IPADDRS" ] && [ $IPADDRALRT ] \
                     || warn '%s\n\t%s' \
                             "There is no IPv4 or IPv6 global scope ip address on interface '$IFC'!" \
-                            "If that is ok, you can disable these alerts with --no-ipaddr-alert."
+                            'If that is ok, you can disable these alerts with --no-ipaddr-alert.'
                 alert LINKUP 'Link up on interface "%s"!' "$IFC"
                 return 0
             }
@@ -1182,7 +1182,7 @@ nexthop() {
               'and be no longer than 236 characters.'
     [ $(printf %s "$SYSTEMDSERVICENAME" | wc -c) -gt 236 ] && \
         USAGE 'Systemd service name\n       "%s"\n       %s' \
-              "$SYSTEMDSERVICENAME" "is too long (max 236 characters)"
+              "$SYSTEMDSERVICENAME" 'is too long (max 236 characters)'
     [ $(id -u) -eq 0 ] || USAGE %s "$nwwatchdog --install-systemd must be run as root"
     [ -d /etc/systemd/system/. ] || USAGE "'/etc/systemd/system/' does not exists,\n       systemd '%s.service' NOT installed!" \
                                           "$SYSTEMDSERVICENAME"


### PR DESCRIPTION
Constant-string quoting cleanup on `nw-watchdog` — minimal quoting where a double-quoted string held no variables. **No behaviour change** (`sh -n` / `dash -n` clean; string values unchanged).

- **5 constant multi-word messages**: `"..."` → `'...'` (single quotes suffice; skips the shell's expansion scan).
- **2 `case` patterns** (`ERROR`, `WARNING`): `"..."` → **bare** — a glob-free word needs no quoting.

Left intentionally double-quoted: the `--help` EXAMPLES `printf` strings — they exist to bypass `fmt` reflowing of the help output (presentation, not logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
