### PR TITLE
Fix quoting-correctness bugs: eval option assignment + trace format

### DIFF
--- a/nw-watchdog
+++ b/nw-watchdog
@@ -823,7 +823,7 @@ while [ $# -gt 0 ]; do
                     ERRMSG="Invalid argument '$ARG' for option '$OPT' $R.\n$ERRMSG"
                     break
                 }
-                eval "$o='$ARG'"
+                eval "$o=\$ARG"
                 break
             fi
         done
@@ -1264,7 +1264,7 @@ isup() {
     # (but unlikely due to -A) return 1 or 2 even if we're up)
     trace 'slow-up failed or ambigious result ... verifying ...'
     ping -q -w2 -c1 -I$IFC $isupADDR >/dev/null  2>&1 && {
-        trace '$isupADDR is verified-up via $IFC'
+        trace '%s is verified-up via %s' "$isupADDR" "$IFC"
         return 0
     }
     # We don't get traffic through


### PR DESCRIPTION
Two small quoting-correctness bugfixes on `nw-watchdog`. `sh -n` / `dash -n` clean; the `eval` fix is validated in dash + busybox sh and end-to-end (`nw-watchdog --alert="it's down" --version` now exits 0 instead of crashing the parser).

- **Option parser `eval` (`:826`)** — `eval "$o='$ARG'"` embeds the raw argument between single quotes, so an argument containing a `'` yields `unterminated quoted string` and **aborts the option parser**. The free-form `--alert` / `--ifcup` / `--ifcdown` / … values pass the `.+` validation, so e.g. `--alert="it's down"` crashed startup. Fixed with `eval "$o=\$ARG"` — `$ARG` expands in assignment context (no field splitting, result not re-parsed), so quotes / whitespace / metacharacters are stored verbatim.
- **`isup` trace (`:1267`)** — `trace '$isupADDR is verified-up via $IFC'` was single-quoted, so the variables never expanded (it printed the literal text). Now uses the standard `'%s …' "$var"` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
