### PR TITLE
Fix printf format-string idiom for pidfile write (:1321)

### DIFF
--- a/nw-watchdog
+++ b/nw-watchdog
@@ -1318,7 +1318,7 @@ PID=$(cat "$PIDFILE")
     exit 0
 }
 
-printf $$ > "$PIDFILE"
+printf %s "$$" > "$PIDFILE"
 debug 'PID=%d BASENAME=%s COMM=%s' $$ "$nwwatchdog" "$(cat /proc/$$/comm)"
 
 debug '\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s\n\t%s' \


### PR DESCRIPTION
Trivial `printf` idiom fix on `nw-watchdog`.

- **`:1321`** — `printf $$ > "$PIDFILE"` passes the PID as the *format string* (SC2059). Harmless for numeric PIDs today, but the correct idiom is `printf %s "$$"` — same output (no trailing newline), so the pidfile content is byte-identical. `sh -n` / `dash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
