### PR TITLE
Remove unnecessary delay when forking

### DIFF
--- a/nw-watchdog
+++ b/nw-watchdog
@@ -1310,10 +1310,10 @@ PID=$(cat "$PIDFILE")
     AOPTS="$AOPTS -p'$PIDFILE'"
     if [ -x "$0" ]; then
         trace 'forking: %s' "'$0' '$TARGET' -D$NOPTS$AOPTS"
-        { sleep 0.25 ; eval "exec '$0' '$TARGET' -D$NOPTS$AOPTS" ;} &
+        { eval "exec '$0' '$TARGET' -D$NOPTS$AOPTS" ;} &
     else
         trace 'forking: %s' "sh '$0' '$TARGET' -D$NOPTS$AOPTS"
-        { sleep 0.25 ;eval "exec sh '$0' '$TARGET' -D$NOPTS$AOPTS" ;} &
+        { eval "exec sh '$0' '$TARGET' -D$NOPTS$AOPTS" ;} &
     fi
     exit 0
 }


### PR DESCRIPTION
Removes the `sleep 0.25` before the daemonize fork/exec — an unnecessary delay with no identified purpose (and a non-POSIX fractional `sleep`). `sh -n` / `dash -n` clean; the fork path still daemonizes and writes its pidfile.
