### PR TITLE
Add DEVELOPMENT.md and stamp main to the PR#-based VERSION scheme

### DIFF
--- a/documentation/DEVELOPMENT.md
+++ b/documentation/DEVELOPMENT.md
@@ -1,0 +1,71 @@
+# Developing nw-watchdog
+
+`nw-watchdog` is a single POSIX-sh program (`nw-watchdog`) plus its documentation.
+This note records the branch model, pull-request flow, and versioning scheme so the
+process isn't only tribal knowledge.
+
+> **This is a development/contributor document — not part of a release.** When a release
+> is cut, exclude `documentation/DEVELOPMENT.md` from the released files.
+
+## Branches
+
+- **`development`** — integration branch. New work happens here, optionally on
+  short-lived feature branches off it.
+- **`main`** — the TESTING branch: stable enough to download and run if you want
+  functionality that isn't in a release yet. Note: unlike many projects, `main` is
+  *not* the latest release — releases are tags (below).
+- **Releases** — git tags `vX.Y.Z`.
+
+After a PR merges into `main`, `development` is fast-forwarded back to it, so the two
+stay in step (they differ only by the `VERSION` line — see Versioning).
+
+## Making changes
+
+Changes reach `main` through pull requests:
+
+1. Work on `development` (or a feature branch off it).
+2. Open a PR into `main`.
+3. The maintainer reviews and merges it, as a **merge commit** (not squash —
+   squashing would make the long-lived `development` branch diverge from `main`).
+4. `development` is fast-forwarded back to `main`.
+
+Force-pushes to `main`/`development` are blocked; fix mistakes with a follow-up commit
+rather than rewriting history.
+
+## Versioning
+
+The `VERSION` line at the top of the `nw-watchdog` script identifies the build.
+`--version` and `--help` treat any version string containing a `-` as unreleased.
+
+| Where              | Format                              | Example                              |
+|--------------------|-------------------------------------|--------------------------------------|
+| Release (tag)      | `X.Y.Z`                             | `1.1.6`                              |
+| `main` (TESTING)   | `X.Y.Z-main-YYYYMMDD-PR#`           | `1.1.6-main-20260707-72`            |
+| `development`      | `<current main version>-development`| `1.1.6-main-20260707-72-development` |
+
+- `X.Y.Z` is the release the build is based on, `YYYYMMDD` the change date, and
+  `PR#` the pull request that introduced it.
+- The maintainer sets the `main` version **inside the PR** — the PR number is known
+  as soon as the PR is opened, so the stamp is visible at review and correct at merge.
+- After the fast-forward sync, `development`'s version is simply the `main` version
+  with `-development` appended.
+
+## Releases
+
+Releases are tags `vX.Y.Z` cut off `main`; there is no permanent release branch.
+
+The step-by-step release procedure will be documented here when the next release is cut.
+Among other things it must exclude development-only docs (this `DEVELOPMENT.md`) from the
+released files.
+
+## Code style & checks
+
+- **POSIX sh** is a hard goal. Linux-only *dependencies* (`ip`, `ping` iputils flags,
+  `/proc`) are intended and fine; non-POSIX *shell-language* constructs are not.
+- Keep the existing terse style; comment the *why*, in English.
+- Before committing, run:
+  - `sh -n nw-watchdog` (and `dash -n nw-watchdog` if available) — syntax check.
+  - `shellcheck nw-watchdog` — should be clean. A `.shellcheckrc` pins `shell=sh` and
+    disables the reviewed-intentional info/style notes.
+- `documentation/help.md` mirrors the built-in `--help`; keep the two in step.
+- Record unreleased changes in `documentation/changelog.md` under the **TESTING** section.

--- a/nw-watchdog
+++ b/nw-watchdog
@@ -158,9 +158,10 @@ EOU
     if printf %s "$VERSION" | grep -q -e-; then $FMT<<EOU
     $VERSION
 
-    This is an unreleased version. The version format for all unreleased versions is:
-    LATESTRELESE-BRANCH-CHANGEDATE-RUNNINGNUMBER
-    where LATESTRELESE is the release this version is based on. BRANCH is the git branch, CHANGEDATE is the date (YYYYMMDD) the latest change was commited and RUNNINGNUMBER indicates how many changes was commited that day.
+    This is an unreleased version. Unreleased versions on the main (TESTING) branch use the format
+    LATESTRELEASE-main-CHANGEDATE-PULLREQUESTNUMBER, where LATESTRELEASE is the release this is based on,
+    CHANGEDATE is the date (YYYYMMDD) of the change, and PULLREQUESTNUMBER is the pull request that introduced it.
+    Development-branch builds append "-development" to the main version they are based on.
 EOU
     else printf '    %s\n' "$VERSION"; fi
     $FMT<<EOU

--- a/nw-watchdog
+++ b/nw-watchdog
@@ -2,7 +2,7 @@
 # The option-table vars (${o}RE / ${o}V / ${o}ARE for SOPTIONS+AOPTIONS) are set and read
 # only via eval-based dispatch, which shellcheck cannot follow -> false SC2034/SC2154:
 # shellcheck disable=SC2034,SC2154
-VERSION=1.1.6-main-20260707-71-development
+VERSION=1.1.6-main-20260708-72
 #
 #       nw-watchdog is a higly configurable network watchdog written
 #       in POSIX shell script for use in Linux.

--- a/nw-watchdog
+++ b/nw-watchdog
@@ -2,7 +2,7 @@
 # The option-table vars (${o}RE / ${o}V / ${o}ARE for SOPTIONS+AOPTIONS) are set and read
 # only via eval-based dispatch, which shellcheck cannot follow -> false SC2034/SC2154:
 # shellcheck disable=SC2034,SC2154
-VERSION=1.1.6
+VERSION=1.1.6-main-20260707-71-development
 #
 #       nw-watchdog is a higly configurable network watchdog written
 #       in POSIX shell script for use in Linux.


### PR DESCRIPTION
First `dev→main` PR under the new versioning scheme. Documentation + version metadata only — no functional code change.

- **New `documentation/DEVELOPMENT.md`** — records the branch model (`development`=integration, `main`=TESTING, releases=tags), the pull-request flow, the VERSION scheme, and the code-style/shellcheck checks, so the process isn't only tribal knowledge. Flagged as a dev-only doc to be excluded from releases; the release procedure itself is left as a stub to fill in at the next release.
- **`--help` VERSION blurb rewritten** to the settled `LATESTRELEASE-main-CHANGEDATE-PULLREQUESTNUMBER` format (development builds append `-development`); also fixes the `LATESTRELESE` / `commited` typos. `documentation/help.md`'s copy follows in the docs mirror.
- **Stamps `main`'s VERSION** to the PR#-based scheme — until now `main` still reported the bare release `1.1.6` despite carrying unreleased fixes. Exact value set once the PR number is known (see the VERSION commit below).