### PR TITLE
Adopt -testing-/-development- version channel scheme

### DIFF
--- a/documentation/DEVELOPMENT.md
+++ b/documentation/DEVELOPMENT.md
@@ -37,18 +37,21 @@ rather than rewriting history.
 The `VERSION` line at the top of the `nw-watchdog` script identifies the build.
 `--version` and `--help` treat any version string containing a `-` as unreleased.
 
-| Where              | Format                              | Example                              |
-|--------------------|-------------------------------------|--------------------------------------|
-| Release (tag)      | `X.Y.Z`                             | `1.1.6`                              |
-| `main` (TESTING)   | `X.Y.Z-main-YYYYMMDD-PR#`           | `1.1.6-main-20260707-72`            |
-| `development`      | `<current main version>-development`| `1.1.6-main-20260707-72-development` |
+| Where            | Format                          | Example                        |
+|------------------|---------------------------------|--------------------------------|
+| Release (tag)    | `X.Y.Z`                         | `1.1.6`                        |
+| `main` (testing) | `X.Y.Z-testing-YYYYMMDD-PR#`    | `1.1.6-testing-20260708-73`    |
+| `development`    | `X.Y.Z-development-YYYYMMDD-PR#` | `1.1.6-development-20260708-73` |
 
-- `X.Y.Z` is the release the build is based on, `YYYYMMDD` the change date, and
-  `PR#` the pull request that introduced it.
-- The maintainer sets the `main` version **inside the PR** — the PR number is known
-  as soon as the PR is opened, so the stamp is visible at review and correct at merge.
-- After the fast-forward sync, `development`'s version is simply the `main` version
-  with `-development` appended.
+- `X.Y.Z` is the release it is based on; `CHANNEL` is `testing` (stable enough to run, normally the
+  next release) or `development` (unstable, in progress); `YYYYMMDD` is the change date; and `PR#` is
+  the pull request that introduced it (for a `development` build, the `testing` build it is based on).
+- The channel word denotes *maturity*, not the branch name, so it stays `testing` even if that branch
+  is later renamed.
+- The maintainer sets the `testing` version **inside the PR** — the PR number is known once the PR is
+  opened, so the stamp is visible at review and correct at merge.
+- After the fast-forward sync, `development`'s version is the `testing` version with the channel word
+  swapped (`testing` → `development`).
 
 ## Releases
 

--- a/nw-watchdog
+++ b/nw-watchdog
@@ -158,10 +158,11 @@ EOU
     if printf %s "$VERSION" | grep -q -e-; then $FMT<<EOU
     $VERSION
 
-    This is an unreleased version. Unreleased versions on the main (TESTING) branch use the format
-    LATESTRELEASE-main-CHANGEDATE-PULLREQUESTNUMBER, where LATESTRELEASE is the release this is based on,
-    CHANGEDATE is the date (YYYYMMDD) of the change, and PULLREQUESTNUMBER is the pull request that introduced it.
-    Development-branch builds append "-development" to the main version they are based on.
+    This is an unreleased version. Unreleased versions use the format
+    LATESTRELEASE-CHANNEL-CHANGEDATE-PULLREQUESTNUMBER, where LATESTRELEASE is the release it is based on,
+    CHANNEL is "testing" (stable enough to run, normally the next release) or "development" (unstable, in
+    progress), CHANGEDATE is the date (YYYYMMDD), and PULLREQUESTNUMBER is the pull request that introduced
+    the change (for a "development" build, the "testing" build it is based on).
 EOU
     else printf '    %s\n' "$VERSION"; fi
     $FMT<<EOU

--- a/nw-watchdog
+++ b/nw-watchdog
@@ -2,7 +2,7 @@
 # The option-table vars (${o}RE / ${o}V / ${o}ARE for SOPTIONS+AOPTIONS) are set and read
 # only via eval-based dispatch, which shellcheck cannot follow -> false SC2034/SC2154:
 # shellcheck disable=SC2034,SC2154
-VERSION=1.1.6-main-20260708-72
+VERSION=1.1.6-main-20260708-72-development
 #
 #       nw-watchdog is a higly configurable network watchdog written
 #       in POSIX shell script for use in Linux.

--- a/nw-watchdog
+++ b/nw-watchdog
@@ -2,7 +2,7 @@
 # The option-table vars (${o}RE / ${o}V / ${o}ARE for SOPTIONS+AOPTIONS) are set and read
 # only via eval-based dispatch, which shellcheck cannot follow -> false SC2034/SC2154:
 # shellcheck disable=SC2034,SC2154
-VERSION=1.1.6-main-20260708-72-development
+VERSION=1.1.6-testing-20260708-73
 #
 #       nw-watchdog is a higly configurable network watchdog written
 #       in POSIX shell script for use in Linux.


### PR DESCRIPTION
Follow-up to #72. Documentation + version metadata only — no functional code change.

Puts a **maturity channel word** in the 2nd field of the version string instead of the branch name:

| Channel | Format |
|---|---|
| release | `X.Y.Z` |
| testing | `X.Y.Z-testing-YYYYMMDD-PR#` |
| development | `X.Y.Z-development-YYYYMMDD-PR#` |

Rationale: `-main-` read as "the release" to anyone holding the common main=release convention — misleading for a testing build. A maturity word self-describes and is decoupled from the branch name (it stays `testing` even if the branch is later renamed `staging`).

- **`--help` VERSION blurb** rewritten to describe the channel format.
- **`DEVELOPMENT.md`** version table + notes updated to match; the post-sync step is now "swap `testing`→`development`" rather than "append `-development`".
- **Stamps `main` VERSION** to `1.1.6-testing-YYYYMMDD-72`-style under the new scheme (exact value set in the VERSION commit once the PR number is known).

`documentation/help.md` is intentionally **not** touched here — it's out of sync on several things and gets the version blurb along with everything else in its own dedicated mirror pass.