### PR TITLE
Changelog: document --help/message corrections + AI-assistance note

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -19,9 +19,13 @@ Unless plans change, they will be in the next release.
 
 * Fixed bug "'Verify-up' trace message printed literal variable names instead of values."
 
+* Fixed bug "The interface-reset failure message referenced --if-up / --if-down, which are not real options (the correct options are --ifcup / --ifcdown)."
+
 * Optimization: removed an unnecessary delay when forking to daemonize.
 
-* Cleanup: consistent minimal quoting, tabs -> spaces indentation, corrected 'printf' idiom, and a shellcheck-clean codebase (with a .shellcheckrc). No functional change.
+* Cleanup: consistent minimal quoting, tabs -> spaces indentation, corrected 'printf' idiom, a shellcheck-clean codebase (with a .shellcheckrc), and corrected --help / comment spelling, grammar and example option names, plus documented the %{LASTSTATE} alert placeholder. No functional change.
+
+_The above was found and corrected with the assistance of AI — Anthropic's Claude (Opus 4.8) — with all changes reviewed and merged by the maintainer._
 
 ## v1.1.6 - Update Release, 2025-02-17
 https://github.com/fraxflax/nw-watchdog/tree/v1.1.6

--- a/nw-watchdog
+++ b/nw-watchdog
@@ -2,7 +2,7 @@
 # The option-table vars (${o}RE / ${o}V / ${o}ARE for SOPTIONS+AOPTIONS) are set and read
 # only via eval-based dispatch, which shellcheck cannot follow -> false SC2034/SC2154:
 # shellcheck disable=SC2034,SC2154
-VERSION=1.1.6-testing-20260708-75
+VERSION=1.1.6-development-20260708-75
 #
 #       nw-watchdog is a highly configurable network watchdog written
 #       in POSIX shell script for use in Linux.

--- a/nw-watchdog
+++ b/nw-watchdog
@@ -2,7 +2,7 @@
 # The option-table vars (${o}RE / ${o}V / ${o}ARE for SOPTIONS+AOPTIONS) are set and read
 # only via eval-based dispatch, which shellcheck cannot follow -> false SC2034/SC2154:
 # shellcheck disable=SC2034,SC2154
-VERSION=1.1.6-development-20260708-75
+VERSION=1.1.6-testing-20260708-76
 #
 #       nw-watchdog is a highly configurable network watchdog written
 #       in POSIX shell script for use in Linux.


### PR DESCRIPTION
Documentation only — no functional code change.

Brings the changelog TESTING section up to date with the script-side changes from the recent documentation PRs:

- **New bugfix bullet** — the interface-reset failure message referenced `--if-up` / `--if-down`, options that don't exist (the real ones are `--ifcup` / `--ifcdown`), so it misdirected anyone troubleshooting a reset.
- **Extended the Cleanup bullet** to cover the `--help` / comment spelling & grammar fixes, the corrected example option names (`--max-nolink`, the strongSwan example), and the newly-documented `%{LASTSTATE}` placeholder.
- **Closing note** that AI (Claude Opus 4.8) assisted in finding and correcting the above, with all changes reviewed and merged by the maintainer.

(The `-testing-`/`-development-` version-string scheme and the `$__` spacing normalization are intentionally not listed — neither is visible in a released build.)

Stamps `main` VERSION under the `-testing-` scheme (exact value in the VERSION commit).