### PR TITLE
Docs: fix VPN-paths example trace timestamps for the functional slow-up test

### DIFF
--- a/documentation/help.md
+++ b/documentation/help.md
@@ -504,32 +504,32 @@ __nw-watchdog__ detects that the connectivity via the VPN-server is lost and bri
 ^^^ and here the full tunnel was brought down again (without replacing it with any of the other vpn-interfaces) 
 ```
 00:00:32  TRACE: quick-up failed ... trying slow-up ...
-00:00:32  TRACE: slow-up failed or ambiguous result ... verifying ...
-00:00:34  TRACE: No reply from target 'vpn.inside.dom' (10.0.10.1), checking link and topology.
-00:00:35  TRACE: quick-up failed ... trying slow-up ...
-00:00:35  TRACE: slow-up failed or ambiguous result ... verifying ...
+00:01:07  TRACE: slow-up failed or ambiguous result ... verifying ...
+00:01:09  TRACE: No reply from target 'vpn.inside.dom' (10.0.10.1), checking link and topology.
+00:01:10  TRACE: quick-up failed ... trying slow-up ...
+00:01:45  TRACE: slow-up failed or ambiguous result ... verifying ...
 ```
 ^^^ Here the __nw-watchdog__ gives up and concludes that the <ins>TARGET</ins> is down. 
 ```
-00:00:37  ALERT: DOWN - Not getting replies from target 'vpn.inside.dom' (10.0.10.1) on interface 'eth0'.
+00:01:47  ALERT: DOWN - Not getting replies from target 'vpn.inside.dom' (10.0.10.1) on interface 'eth0'.
                  Resetting interface:
                  ifdown vpnL ; ifdown vpnP ; ifdown vpnF
                  ifup vpnL
-00:00:37   INFO: Resetting interface (eth0).
+00:01:47   INFO: Resetting interface (eth0).
 ```
 ^^^ This can be confusing since it's actually not eth0 that is reset (but it's the current source interface)<br>
 Below we see that the watchdog actually brings down all the vpn-interfaces and brings up `vpnL` 
 ```
-00:00:37  TRACE: sh -c 'ifdown vpnL ; ifdown vpnP ; ifdown vpnF'
-00:00:38  TRACE: sh -c 'ifup vpnL'
-00:00:38  TRACE: Sleeping for 35 seconds.
+00:01:47  TRACE: sh -c 'ifdown vpnL ; ifdown vpnP ; ifdown vpnF'
+00:01:48  TRACE: sh -c 'ifup vpnL'
+00:01:48  TRACE: Sleeping for 35 seconds.
 ```
 ^^^ This is the grace period we have set in `--ifup-grace`
 ```
-00:01:13   INFO: Detected topology: IFC='eth0' -> 'vpnL' ; NEXTHOP='192.168.0.1' -> '10.0.10.1'
-00:01:13  TRACE: Continuously checking if target is up...
-00:01:13  TRACE: ... and for changes in topology
-00:01:13  ALERT: UP - Target 'vpn.inside.dom' (10.0.10.1) is up.
+00:02:23   INFO: Detected topology: IFC='eth0' -> 'vpnL' ; NEXTHOP='192.168.0.1' -> '10.0.10.1'
+00:02:23  TRACE: Continuously checking if target is up...
+00:02:23  TRACE: ... and for changes in topology
+00:02:23  ALERT: UP - Target 'vpn.inside.dom' (10.0.10.1) is up.
 ```
 
 ## DEPENDENCIES <a name="deps"></a>

--- a/nw-watchdog
+++ b/nw-watchdog
@@ -686,31 +686,31 @@ $_b_    ^^^^^^^^^^^^^^^^$__
 $_b_    and here the full tunnel was brought down again (without replacing it with any of the other vpn-interfaces)$__
 
     00:00:32  TRACE: quick-up failed ... trying slow-up ...
-    00:00:32  TRACE: slow-up failed or ambiguous result ... verifying ...
-    00:00:34  TRACE: No reply from target 'vpn.inside.dom' (10.0.10.1), checking link and topology.
-    00:00:35  TRACE: quick-up failed ... trying slow-up ...
-    00:00:35  TRACE: slow-up failed or ambiguous result ... verifying ...
+    00:01:07  TRACE: slow-up failed or ambiguous result ... verifying ...
+    00:01:09  TRACE: No reply from target 'vpn.inside.dom' (10.0.10.1), checking link and topology.
+    00:01:10  TRACE: quick-up failed ... trying slow-up ...
+    00:01:45  TRACE: slow-up failed or ambiguous result ... verifying ...
 $_b_    ^^^^^^^^^^^^^^^^$__
 $_b_    Here the $nwwatchdog gives up and concludes that the ${___}TARGET${__}$_b_ is down.$__
 
-    00:00:37  ALERT: DOWN - Not getting replies from target 'vpn.inside.dom' (10.0.10.1) on interface 'eth0'.
+    00:01:47  ALERT: DOWN - Not getting replies from target 'vpn.inside.dom' (10.0.10.1) on interface 'eth0'.
                      Resetting interface:
                      ifdown vpnL ; ifdown vpnP ; ifdown vpnF
                      ifup vpnL
-    00:00:37   INFO: Resetting interface (eth0).
+    00:01:47   INFO: Resetting interface (eth0).
 $_b_    ^^^^^^^^^^^^^^^^                      ^^^^$__
 $_b_    This can be confusing since it's actually not eth0 that is reset (but it's the current source interface)$__
 $_b_    Below we see that the watchdog actually brings down all the vpn-interfaces and brings up vpnL$__
 
-    00:00:37  TRACE: sh -c 'ifdown vpnL ; ifdown vpnP ; ifdown vpnF'
-    00:00:38  TRACE: sh -c 'ifup vpnL'
-    00:00:38  TRACE: Sleeping for 35 seconds.
+    00:01:47  TRACE: sh -c 'ifdown vpnL ; ifdown vpnP ; ifdown vpnF'
+    00:01:48  TRACE: sh -c 'ifup vpnL'
+    00:01:48  TRACE: Sleeping for 35 seconds.
 $_b_    ^^^^^^^^^^^^^^^^$__
 $_b_    This is the grace period we have set in --ifup-grace$__
-    00:01:13   INFO: Detected topology: IFC='eth0' -> 'vpnL' ; NEXTHOP='192.168.0.1' -> '10.0.10.1'
-    00:01:13  TRACE: Continuously checking if target is up...
-    00:01:13  TRACE: ... and for changes in topology
-    00:01:13  ALERT: UP - Target 'vpn.inside.dom' (10.0.10.1) is up.
+    00:02:23   INFO: Detected topology: IFC='eth0' -> 'vpnL' ; NEXTHOP='192.168.0.1' -> '10.0.10.1'
+    00:02:23  TRACE: Continuously checking if target is up...
+    00:02:23  TRACE: ... and for changes in topology
+    00:02:23  ALERT: UP - Target 'vpn.inside.dom' (10.0.10.1) is up.
 EOU
     $FMT <<EOU
 

--- a/nw-watchdog
+++ b/nw-watchdog
@@ -2,7 +2,7 @@
 # The option-table vars (${o}RE / ${o}V / ${o}ARE for SOPTIONS+AOPTIONS) are set and read
 # only via eval-based dispatch, which shellcheck cannot follow -> false SC2034/SC2154:
 # shellcheck disable=SC2034,SC2154
-VERSION=1.1.6-development-20260708-76
+VERSION=1.1.6-testing-20260708-77
 #
 #       nw-watchdog is a highly configurable network watchdog written
 #       in POSIX shell script for use in Linux.

--- a/nw-watchdog
+++ b/nw-watchdog
@@ -2,7 +2,7 @@
 # The option-table vars (${o}RE / ${o}V / ${o}ARE for SOPTIONS+AOPTIONS) are set and read
 # only via eval-based dispatch, which shellcheck cannot follow -> false SC2034/SC2154:
 # shellcheck disable=SC2034,SC2154
-VERSION=1.1.6-testing-20260708-76
+VERSION=1.1.6-development-20260708-76
 #
 #       nw-watchdog is a highly configurable network watchdog written
 #       in POSIX shell script for use in Linux.


### PR DESCRIPTION
Documentation only — no functional code change.

The "Several VPN paths with one preferred interface" example trace (in the `--help` EXAMPLES section and `documentation/help.md`) was recorded **before** the slow-up test was fixed — back when it failed instantly (empty ping deadline/count), so `quick-up failed` and `slow-up failed … verifying` shared the same second.

Now that the slow-up runs for real, each down-detection cycle spends ~35 s in the slow-up (`--slow-up-timeout=7 × SUCOUNT=5`). The example's timestamps are adjusted to reflect that:

- slow-up#1 verify `00:00:32 → 00:01:07`, no-reply `00:01:09`
- quick-up#2 `00:01:10`, slow-up#2 verify `00:01:45`, DOWN `00:01:47`
- reset `00:01:47`, ifup `00:01:48`, 35 s grace → recovery/UP `00:02:23`

Message sequence and content are unchanged; only the timestamps stretch. Verified: `sh -n` clean, codespell clean, and the two files' trace blocks match. Stamps `main` VERSION under the `-testing-` scheme.

(No changelog entry — it's an example-only cosmetic adjustment.)